### PR TITLE
Fix M5 NAX gray-noise bug: swap in prebuilt mlx.metallib when miscompiled

### DIFF
--- a/docs/m5-metal.md
+++ b/docs/m5-metal.md
@@ -1,129 +1,60 @@
-# M5 (Apple GPU gen ≥ 17) gray-noise bug — root cause & fix
+# M5 (Apple GPU gen ≥ 17) gray-noise bug
 
-> **Most users don't need to read this.** `setup.sh` detects the miscompile
-> automatically and either applies the fix (ternary) or prints the stopgap
-> (binary). This doc is background + reference for when the automatic path
-> doesn't cover you: the binary (1-bit) model, modifying `.metal` kernels, or
-> rebasing the fork.
+> **You probably don't need this.** `setup.sh` detects the bug and fixes it
+> automatically for the ternary model. Read on only if the automatic fix
+> doesn't apply: the binary (1-bit) model, editing `.metal` kernels, or
+> bumping the mlx fork.
 
-## Symptom
-On M5 / M5 Pro / M5 Max, every generation is the same gray-brown noise texture
-(`mean≈116, std≈8.7`) regardless of prompt, seed, size, or steps. M4 and earlier
-are unaffected. Tracked in issue #6.
+## What you'd see
+On M5 / M5 Pro / M5 Max, every generation is the same gray-brown noise
+(`mean≈116, std≈8.7`) regardless of prompt/seed/size. M4 and earlier are fine.
+Tracked in issue #6.
 
-## Root cause
-**Xcode 26.5 / Metal toolchain `metalfe-32023.883` miscompiles MLX's M5-only
-NAX (Neural Accelerator) GEMM Metal shaders.** It is *not* an mlx source bug and
-*not* a hardware bug:
-
-- bf16/fp16 matmul on M5 returns decorrelated, ~½-magnitude garbage (`A@B` GPU vs
-  CPU relative error ≈ **1.1**); fp32 is fine.
-- This corrupts every transformer matmul → the text conditioning is washed out →
-  the model collapses to a fixed noise attractor (prompt has no effect). The VAE
-  and text encoder are fine.
-- M4 never runs the NAX path, so the miscompiled kernels are never executed there.
-
-Evidence that it is the *compiled metallib*, not the source:
-
-| mlx build | metallib compiled by | bf16 `A@B` GPU-vs-CPU | result |
-|---|---|---|---|
-| fork `b9effaf6`, local | Xcode 26.5 | ~1.1 | ❌ noise |
-| upstream `v0.31.2`, local | Xcode 26.5 | ~1.1 | ❌ noise |
-| upstream `a6222f53d`/`2414e5df6`, local | Xcode 26.5 | ~1.1 | ❌ noise |
-| prebuilt PyPI `mlx-metal` 0.31.2 | mlx CI (SDK 26.4) | ~1e-3 | ✅ correct |
-
-Swapping *only* the `mlx.metallib` (26.4-compiled → into the otherwise-broken
-local build) flips it from broken to correct. Same `.so`, same source, same M5.
+## Why
+Xcode 26.5's Metal toolchain (`metalfe-32023.883`) miscompiles MLX's M5-only
+NAX GEMM shaders, so bf16 matmul on the GPU returns ~½-magnitude garbage
+(`A@B` GPU-vs-CPU error ≈ 1.1; fp32 is fine). That washes out the transformer's
+text conditioning, collapsing every prompt to the same noise. It's the *locally
+compiled* `mlx.metallib`, not the mlx source: dropping in a CI-compiled metallib
+(same `.so`, same source) flips it from broken to correct.
 Upstream: https://github.com/ml-explore/mlx/issues/3586
 
-## Ternary vs binary — they need different fixes
-This matters because the mlx fork's 1-bit support **adds custom Metal kernels**
-(`quantized.metal`, `quantized_nax.metal`), and upstream mlx has **no 1-bit
-support at all** (v0.31.2 `ops.cpp` rejects `bits < 2`).
+## What `setup.sh` does (ternary, automatic)
+Runs a bf16 GPU-vs-CPU matmul check; if the local build is miscompiled, it
+overwrites the source-built `mlx.metallib` with the matching prebuilt
+`mlx-metal` wheel and re-verifies. Keeps NAX on → correct and full speed.
 
-- **Ternary (2-bit):** uses the *standard* upstream quant/NAX kernels, which are
-  present in the prebuilt `mlx-metal` wheel. → Fix A (prebuilt metallib) works,
-  full NAX speed. The fork isn't even required for ternary.
-- **Binary (1-bit):** needs the fork's custom 1-bit kernels, which are **not** in
-  the stock wheel. Dropping in the prebuilt metallib would remove them. → on M5,
-  build the fork metallib with Xcode 26.4 (Fix B), run NAX-off (`g16s`), or get
-  1-bit support upstreamed (see below).
+## Fallbacks (when the automatic swap doesn't apply)
 
-## Fix A — ship the prebuilt `mlx-metal` metallib (ternary; default in `setup.sh`)
-`setup.sh` step 5b, when the variant is **ternary**, builds the fork's mlx *core*
-from source, overwrites the locally-compiled `mlx.metallib` with the matching
-prebuilt `mlx-metal` wheel, and verifies the GPU matmul is correct. For the
-**binary** variant it skips the swap (to preserve 1-bit kernels) and prints the
-`g16s` / Xcode-26.4 guidance.
+**Quickest stopgap — disable NAX (any variant, no rebuild):** correct but
+~2.5–3× slower (drops to the M4 kernel path).
+```sh
+export MLX_METAL_GPU_ARCH=applegpu_g16s
+```
 
-This keeps NAX **enabled** → correct **and** fastest (it also picks up newer NAX
-tuning than the fork's pinned base):
+**Binary (1-bit) model:** the swap is skipped — the prebuilt wheel lacks the
+fork's custom 1-bit kernels, so it can't replace the metallib. Use the `g16s`
+stopgap above, or build the metallib with the **Xcode 26.4** toolchain:
+```sh
+xcodes install 26.4
+sudo xcode-select --switch /Applications/Xcode-26.4.app/Contents/Developer
+xcodebuild -downloadComponent MetalToolchain
+# then rebuild mlx from source
+```
 
-| config (512² / 1024², warm) | correct | speed |
-|---|---|---|
-| fork native NAX (old, broken) | ❌ | 2.79 s / 10.46 s |
-| `MLX_METAL_GPU_ARCH=g16s` (NAX off) | ✅ | 6.92 s / 24.07 s |
-| **rebased core + prebuilt 0.31.2 metallib** | ✅ | **2.27 s / 8.65 s** |
-
-**Requirement:** the built mlx version must match a released `mlx-metal` wheel,
-so the fork must be pinned to a tagged release (e.g. **0.31.2**), not an arbitrary
-dev commit. See "Rebasing the fork" below.
-
-## Rebasing the fork onto a tagged mlx (required for Fix A)
-The fork's only change is one line in `mlx/backend/metal/quantized.cpp`:
-
+**Bumping the mlx fork:** the prebuilt swap needs the built mlx version to match
+a released `mlx-metal` wheel, so pin the fork to a tagged release (e.g. 0.31.2),
+not a dev commit. The fork's only change is one line in
+`mlx/backend/metal/quantized.cpp` (guard the 1-bit fast path):
 ```diff
 -  if ((K == 128 || K == 64) && is_power_of_2(bits)) {
 +  if ((K == 128 || (K == 64 && bits >= 2)) && is_power_of_2(bits)) {
 ```
+Reapply it on `v0.31.2`, push, and point `vendor/image-studio/pyproject.toml`'s
+`[tool.uv.sources]` mlx `rev` at the new commit.
 
-Reapply it on top of `v0.31.2` (latest 0.31.x; satisfies mflux's `<0.32.0`):
-
-```sh
-git clone https://github.com/ml-explore/mlx.git && cd mlx
-git checkout -b m5-fix-0.31.2 v0.31.2
-# apply the one-line guard above to mlx/backend/metal/quantized.cpp
-git commit -am "Guard fast-path Metal kernel dispatch for 1-bit quantization"
-git push <PrismML-Eng/mlx remote> m5-fix-0.31.2
-```
-
-Then point the build at the new rev in `vendor/image-studio/pyproject.toml`:
-
-```toml
-[tool.uv.sources]
-mlx = { git = "https://github.com/PrismML-Eng/mlx.git", rev = "<new sha>" }
-```
-
-(Verified: `v0.31.2 + this patch` core, built locally, + prebuilt 0.31.2
-metallib → matmul correct, images clean.)
-
-## Fix B — compile the metallib locally with the Xcode 26.4 toolchain (belt & suspenders)
-If you must build the metallib from source (e.g. you modify `.metal` kernels),
-use the **Xcode 26.4** Metal toolchain instead of 26.5:
-
-```sh
-xcodes install 26.4            # ~10 GB, Apple-ID gated
-sudo xcode-select --switch /Applications/Xcode-26.4.app/Contents/Developer
-xcodebuild -downloadComponent MetalToolchain   # pulls the 26.4 toolchain
-# then rebuild mlx from source as usual
-```
-
-Correct, but does **not** include newer NAX tuning unless you also rebase the
-fork — so Fix A is preferred.
-
-## Best long-term — upstream the 1-bit support, then drop the fork
+## Long-term
 Upstream mlx rejects `bits < 2`, so the fork exists almost entirely for the
-binary (1-bit) model. If the fork's 1-bit affine-quant kernels are upstreamed
-(PR to ml-explore/mlx), then a released `mlx` + prebuilt `mlx-metal` would cover
-**both** ternary and binary — no fork, no local metallib compile, so the Xcode
-26.5 miscompile never enters the picture and both models run correct + full NAX
-speed on M5. The 1-bit dispatch guard / qmv_fast fix would go in the same PR.
-Until then: ternary via Fix A, binary via Fix B or the stopgap below.
-
-## Stopgap — disable NAX (no rebuild)
-Immediate, toolchain-independent, but ~2.5–3× slower (drops to the M4 kernel
-path):
-
-```sh
-export MLX_METAL_GPU_ARCH=applegpu_g16s
-```
+binary model. Upstreaming the 1-bit kernels would let a released `mlx` +
+prebuilt `mlx-metal` cover both variants — no fork, no local metallib compile,
+so the miscompile never applies.

--- a/docs/m5-metal.md
+++ b/docs/m5-metal.md
@@ -1,5 +1,11 @@
 # M5 (Apple GPU gen ≥ 17) gray-noise bug — root cause & fix
 
+> **Most users don't need to read this.** `setup.sh` detects the miscompile
+> automatically and either applies the fix (ternary) or prints the stopgap
+> (binary). This doc is background + reference for when the automatic path
+> doesn't cover you: the binary (1-bit) model, modifying `.metal` kernels, or
+> rebasing the fork.
+
 ## Symptom
 On M5 / M5 Pro / M5 Max, every generation is the same gray-brown noise texture
 (`mean≈116, std≈8.7`) regardless of prompt, seed, size, or steps. M4 and earlier

--- a/docs/m5-metal.md
+++ b/docs/m5-metal.md
@@ -1,0 +1,123 @@
+# M5 (Apple GPU gen ≥ 17) gray-noise bug — root cause & fix
+
+## Symptom
+On M5 / M5 Pro / M5 Max, every generation is the same gray-brown noise texture
+(`mean≈116, std≈8.7`) regardless of prompt, seed, size, or steps. M4 and earlier
+are unaffected. Tracked in issue #6.
+
+## Root cause
+**Xcode 26.5 / Metal toolchain `metalfe-32023.883` miscompiles MLX's M5-only
+NAX (Neural Accelerator) GEMM Metal shaders.** It is *not* an mlx source bug and
+*not* a hardware bug:
+
+- bf16/fp16 matmul on M5 returns decorrelated, ~½-magnitude garbage (`A@B` GPU vs
+  CPU relative error ≈ **1.1**); fp32 is fine.
+- This corrupts every transformer matmul → the text conditioning is washed out →
+  the model collapses to a fixed noise attractor (prompt has no effect). The VAE
+  and text encoder are fine.
+- M4 never runs the NAX path, so the miscompiled kernels are never executed there.
+
+Evidence that it is the *compiled metallib*, not the source:
+
+| mlx build | metallib compiled by | bf16 `A@B` GPU-vs-CPU | result |
+|---|---|---|---|
+| fork `b9effaf6`, local | Xcode 26.5 | ~1.1 | ❌ noise |
+| upstream `v0.31.2`, local | Xcode 26.5 | ~1.1 | ❌ noise |
+| upstream `a6222f53d`/`2414e5df6`, local | Xcode 26.5 | ~1.1 | ❌ noise |
+| prebuilt PyPI `mlx-metal` 0.31.2 | mlx CI (SDK 26.4) | ~1e-3 | ✅ correct |
+
+Swapping *only* the `mlx.metallib` (26.4-compiled → into the otherwise-broken
+local build) flips it from broken to correct. Same `.so`, same source, same M5.
+Upstream: https://github.com/ml-explore/mlx/issues/3586
+
+## Ternary vs binary — they need different fixes
+This matters because the mlx fork's 1-bit support **adds custom Metal kernels**
+(`quantized.metal`, `quantized_nax.metal`), and upstream mlx has **no 1-bit
+support at all** (v0.31.2 `ops.cpp` rejects `bits < 2`).
+
+- **Ternary (2-bit):** uses the *standard* upstream quant/NAX kernels, which are
+  present in the prebuilt `mlx-metal` wheel. → Fix A (prebuilt metallib) works,
+  full NAX speed. The fork isn't even required for ternary.
+- **Binary (1-bit):** needs the fork's custom 1-bit kernels, which are **not** in
+  the stock wheel. Dropping in the prebuilt metallib would remove them. → on M5,
+  build the fork metallib with Xcode 26.4 (Fix B), run NAX-off (`g16s`), or get
+  1-bit support upstreamed (see below).
+
+## Fix A — ship the prebuilt `mlx-metal` metallib (ternary; default in `setup.sh`)
+`setup.sh` step 5b, when the variant is **ternary**, builds the fork's mlx *core*
+from source, overwrites the locally-compiled `mlx.metallib` with the matching
+prebuilt `mlx-metal` wheel, and verifies the GPU matmul is correct. For the
+**binary** variant it skips the swap (to preserve 1-bit kernels) and prints the
+`g16s` / Xcode-26.4 guidance.
+
+This keeps NAX **enabled** → correct **and** fastest (it also picks up newer NAX
+tuning than the fork's pinned base):
+
+| config (512² / 1024², warm) | correct | speed |
+|---|---|---|
+| fork native NAX (old, broken) | ❌ | 2.79 s / 10.46 s |
+| `MLX_METAL_GPU_ARCH=g16s` (NAX off) | ✅ | 6.92 s / 24.07 s |
+| **rebased core + prebuilt 0.31.2 metallib** | ✅ | **2.27 s / 8.65 s** |
+
+**Requirement:** the built mlx version must match a released `mlx-metal` wheel,
+so the fork must be pinned to a tagged release (e.g. **0.31.2**), not an arbitrary
+dev commit. See "Rebasing the fork" below.
+
+## Rebasing the fork onto a tagged mlx (required for Fix A)
+The fork's only change is one line in `mlx/backend/metal/quantized.cpp`:
+
+```diff
+-  if ((K == 128 || K == 64) && is_power_of_2(bits)) {
++  if ((K == 128 || (K == 64 && bits >= 2)) && is_power_of_2(bits)) {
+```
+
+Reapply it on top of `v0.31.2` (latest 0.31.x; satisfies mflux's `<0.32.0`):
+
+```sh
+git clone https://github.com/ml-explore/mlx.git && cd mlx
+git checkout -b m5-fix-0.31.2 v0.31.2
+# apply the one-line guard above to mlx/backend/metal/quantized.cpp
+git commit -am "Guard fast-path Metal kernel dispatch for 1-bit quantization"
+git push <PrismML-Eng/mlx remote> m5-fix-0.31.2
+```
+
+Then point the build at the new rev in `vendor/image-studio/pyproject.toml`:
+
+```toml
+[tool.uv.sources]
+mlx = { git = "https://github.com/PrismML-Eng/mlx.git", rev = "<new sha>" }
+```
+
+(Verified: `v0.31.2 + this patch` core, built locally, + prebuilt 0.31.2
+metallib → matmul correct, images clean.)
+
+## Fix B — compile the metallib locally with the Xcode 26.4 toolchain (belt & suspenders)
+If you must build the metallib from source (e.g. you modify `.metal` kernels),
+use the **Xcode 26.4** Metal toolchain instead of 26.5:
+
+```sh
+xcodes install 26.4            # ~10 GB, Apple-ID gated
+sudo xcode-select --switch /Applications/Xcode-26.4.app/Contents/Developer
+xcodebuild -downloadComponent MetalToolchain   # pulls the 26.4 toolchain
+# then rebuild mlx from source as usual
+```
+
+Correct, but does **not** include newer NAX tuning unless you also rebase the
+fork — so Fix A is preferred.
+
+## Best long-term — upstream the 1-bit support, then drop the fork
+Upstream mlx rejects `bits < 2`, so the fork exists almost entirely for the
+binary (1-bit) model. If the fork's 1-bit affine-quant kernels are upstreamed
+(PR to ml-explore/mlx), then a released `mlx` + prebuilt `mlx-metal` would cover
+**both** ternary and binary — no fork, no local metallib compile, so the Xcode
+26.5 miscompile never enters the picture and both models run correct + full NAX
+speed on M5. The 1-bit dispatch guard / qmv_fast fix would go in the same PR.
+Until then: ternary via Fix A, binary via Fix B or the stopgap below.
+
+## Stopgap — disable NAX (no rebuild)
+Immediate, toolchain-independent, but ~2.5–3× slower (drops to the M4 kernel
+path):
+
+```sh
+export MLX_METAL_GPU_ARCH=applegpu_g16s
+```

--- a/setup.sh
+++ b/setup.sh
@@ -345,7 +345,16 @@ info "mflux installed (versions <= $_pkg_cutoff)."
 #     binary on M5 we keep the fork metallib and fall back to NAX-off (g16s),
 #     or you must compile the fork metallib with the Xcode 26.4 toolchain.
 # See docs/m5-metal.md.
+#
+# The ternary swap is destructive for binary (it strips the fork's 1-bit
+# kernels), and the variant is normally chosen per-invocation at generation
+# time, not via BONSAI_VARIANT at setup time. So besides the env var, we refuse
+# to swap whenever a 1-bit model is already present under models/. Binary users
+# who run setup before downloading a model should export BONSAI_VARIANT=binary.
 _variant="${BONSAI_VARIANT:-ternary}"
+for _bin_model in "$SCRIPT_DIR"/models/bonsai-image-4B-binary-*; do
+    [ -d "$_bin_model" ] && _variant="binary" && break
+done
 
 # bf16 GPU-vs-CPU matmul check: exit 0 if the GPU kernel is correct (reldiff
 # < 0.1), 1 if it's miscompiled (the M5 NAX bug gives reldiff ~1.1).
@@ -382,20 +391,23 @@ if [ "$OS" = "Darwin" ]; then
                 if [ -n "$_good" ]; then
                     cp "$_good" "$_mlx_lib"
                     info "Replaced source-built metallib with prebuilt mlx-metal $_mlx_ver."
+                    # Re-verify only after an actual swap, so the result message
+                    # reflects the swap rather than a path where nothing changed.
+                    if _mlx_matmul_ok; then
+                        info "M5 NAX matmul kernel verified correct after metallib swap."
+                    else
+                        warn "GPU matmul still incorrect after swap. Set MLX_METAL_GPU_ARCH=applegpu_g16s,"
+                        warn "or build mlx's metallib with the Xcode 26.4 toolchain (docs/m5-metal.md)."
+                    fi
                 else
-                    warn "mlx-metal $_mlx_ver had no metallib; skipping."
+                    warn "mlx-metal $_mlx_ver had no metallib; skipping the swap."
+                    warn "M5 users: export MLX_METAL_GPU_ARCH=applegpu_g16s as a fallback (correct, ~2.5-3x slower)."
                 fi
             else
                 warn "No prebuilt mlx-metal==$_mlx_ver (mlx must be pinned to a released version, e.g. 0.31.2)."
                 warn "M5 users: export MLX_METAL_GPU_ARCH=applegpu_g16s as a fallback (correct, ~2.5-3x slower)."
             fi
             rm -rf "$_tmpd"
-            if _mlx_matmul_ok; then
-                info "M5 NAX matmul kernel verified correct after metallib swap."
-            else
-                warn "GPU matmul still incorrect after swap. Set MLX_METAL_GPU_ARCH=applegpu_g16s,"
-                warn "or build mlx's metallib with the Xcode 26.4 toolchain (docs/m5-metal.md)."
-            fi
         fi
     fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -322,6 +322,85 @@ _uv_sync_with_retry
 info "mflux installed (versions <= $_pkg_cutoff)."
 
 # ────────────────────────────────────────────────────
+#  5b. M5 NAX metallib fix (Metal-compiler miscompile workaround)
+# ────────────────────────────────────────────────────
+# Xcode 26.5 / metalfe-32023.883 miscompiles MLX's M5-only NAX GEMM shaders,
+# so the locally compiled mlx.metallib produces garbage matmuls on M5+ (Apple
+# GPU gen >= 17) — the "gray-brown noise" bug. The shaders themselves are fine:
+# the prebuilt `mlx-metal` wheel (compiled with a correct SDK) works.
+# See PrismML/Bonsai-Image-Demo#6 and ml-explore/mlx#3586.
+#
+# Gate-first: we detect the miscompile with a bf16 GPU-vs-CPU matmul check and
+# ONLY swap the metallib when it's actually broken. So M4 (NAX path unused) and
+# any machine with a fixed Xcode/Metal toolchain keep their native build
+# untouched — no needless 150 MB download, and the binary variant keeps the
+# fork's custom kernels unless the bug is genuinely present.
+#
+# IMPORTANT — ternary vs binary (only matters when the bug IS detected):
+#   * ternary (2-bit) uses standard upstream kernels, present in the prebuilt
+#     `mlx-metal` wheel, so we can drop the prebuilt metallib in over the
+#     source-built one. Correct + full NAX speed.
+#   * binary (1-bit) needs the fork's CUSTOM 1-bit kernels (quantized*.metal),
+#     which are NOT in the stock wheel — swapping would remove them. So for
+#     binary on M5 we keep the fork metallib and fall back to NAX-off (g16s),
+#     or you must compile the fork metallib with the Xcode 26.4 toolchain.
+# See docs/m5-metal.md.
+_variant="${BONSAI_VARIANT:-ternary}"
+
+# bf16 GPU-vs-CPU matmul check: exit 0 if the GPU kernel is correct (reldiff
+# < 0.1), 1 if it's miscompiled (the M5 NAX bug gives reldiff ~1.1).
+_mlx_matmul_ok() {
+    "$VENV_PY" - <<'PYV'
+import sys, mlx.core as mx
+a = mx.random.normal((64, 512)).astype(mx.bfloat16)
+b = mx.random.normal((512, 512)).astype(mx.bfloat16); mx.eval(a, b)
+with mx.stream(mx.gpu): g = (a @ b); mx.eval(g)
+with mx.stream(mx.cpu): c = (a @ b); mx.eval(c)
+g = g.astype(mx.float32); c = c.astype(mx.float32); mx.eval(g, c)
+rd = float(((g - c) ** 2).sum() ** 0.5) / (float((c ** 2).sum() ** 0.5) + 1e-9)
+sys.exit(0 if rd < 0.1 else 1)
+PYV
+}
+
+if [ "$OS" = "Darwin" ]; then
+    step "Checking GPU matmul kernel (M5 NAX miscompile detection) ..."
+    if _mlx_matmul_ok; then
+        info "GPU matmul correct — native mlx build is good, no metallib swap needed."
+    elif [ "$_variant" = "binary" ]; then
+        warn "M5 NAX miscompile detected, but binary (1-bit) relies on the fork's custom"
+        warn "kernels that the prebuilt metallib lacks — cannot swap. Run with:"
+        warn "  MLX_METAL_GPU_ARCH=applegpu_g16s   (correct, ~2.5-3x slower)"
+        warn "or build the fork metallib with the Xcode 26.4 toolchain (docs/m5-metal.md)."
+    else
+        step "M5 NAX miscompile detected — applying prebuilt mlx-metal metallib fix (ternary) ..."
+        _mlx_ver="$("$VENV_PY" -c 'import re,mlx.core as mx; m=re.match(r"\d+\.\d+\.\d+", mx.__version__); print(m.group() if m else "")' 2>/dev/null)"
+        _mlx_lib="$("$VENV_PY" -c 'import os,mlx; print(os.path.join(os.path.dirname(mlx.__file__), "lib", "mlx.metallib"))' 2>/dev/null)"
+        if [ -n "$_mlx_ver" ] && [ -f "$_mlx_lib" ]; then
+            _tmpd="$(mktemp -d)"
+            if uv pip install --target "$_tmpd" "mlx-metal==$_mlx_ver" >/dev/null 2>&1; then
+                _good="$(find "$_tmpd" -name mlx.metallib 2>/dev/null | head -1)"
+                if [ -n "$_good" ]; then
+                    cp "$_good" "$_mlx_lib"
+                    info "Replaced source-built metallib with prebuilt mlx-metal $_mlx_ver."
+                else
+                    warn "mlx-metal $_mlx_ver had no metallib; skipping."
+                fi
+            else
+                warn "No prebuilt mlx-metal==$_mlx_ver (mlx must be pinned to a released version, e.g. 0.31.2)."
+                warn "M5 users: export MLX_METAL_GPU_ARCH=applegpu_g16s as a fallback (correct, ~2.5-3x slower)."
+            fi
+            rm -rf "$_tmpd"
+            if _mlx_matmul_ok; then
+                info "M5 NAX matmul kernel verified correct after metallib swap."
+            else
+                warn "GPU matmul still incorrect after swap. Set MLX_METAL_GPU_ARCH=applegpu_g16s,"
+                warn "or build mlx's metallib with the Xcode 26.4 toolchain (docs/m5-metal.md)."
+            fi
+        fi
+    fi
+fi
+
+# ────────────────────────────────────────────────────
 #  6. Wire bundled Node.js into .venv/bin
 # ────────────────────────────────────────────────────
 # `nodejs-wheel-binaries` drops node + npm under


### PR DESCRIPTION
## What
Fixes the M5 (Apple GPU gen ≥ 17) "gray-brown noise" bug (#6) where every generation produces the same noise texture regardless of prompt/seed/size. `setup.sh` now detects the broken GPU matmul kernel and, only when it's actually broken, swaps the locally-built `mlx.metallib` for the prebuilt (correctly-compiled) `mlx-metal` wheel. Adds `docs/m5-metal.md` documenting the root cause.

## Why
**Xcode 26.5 / Metal toolchain `metalfe-32023.883` miscompiles MLX's M5-only NAX GEMM shaders.** It is *not* an mlx source bug and *not* a hardware bug:

- bf16/fp16 `A@B` on the M5 GPU returns decorrelated, ~½-magnitude garbage (GPU-vs-CPU relative error ≈ **1.1**); fp32 is fine.
- That corrupts every transformer matmul → text conditioning washes out → the model collapses to a fixed noise attractor (prompt has no effect). Text encoder and VAE are fine.
- M4 never runs the NAX path, so it's unaffected.

The decisive evidence is that swapping **only** the compiled `mlx.metallib` (CI-compiled, SDK 26.4) into the otherwise-identical local build flips it from broken to correct — same `.so`, same source, same M5. A from-scratch recompile after a macOS update reproduced a **byte-identical** broken metallib, confirming the local Metal compiler is the culprit. Full table in `docs/m5-metal.md`. Upstream: ml-explore/mlx#3586.

## How
In `setup.sh` (section 5b), gate-first:

1. Run a bf16 GPU-vs-CPU matmul check (`_mlx_matmul_ok`).
2. **Correct** → keep the native build, no swap (M4 / fixed toolchains skip the 150 MB download entirely).
3. **Broken + ternary** → `uv pip install mlx-metal==<ver>` into a temp dir, copy its `mlx.metallib` over the source-built one, then **re-verify**.
4. **Broken + binary (1-bit)** → can't swap (the prebuilt wheel lacks the fork's custom 1-bit kernels); warn to use `MLX_METAL_GPU_ARCH=applegpu_g16s` (correct, ~2.5–3× slower).

## Testing
On an M5 Pro (macOS 26.5, Xcode 26.5):
- Matmul check correctly flags the local build (reldiff ~1.11) and passes after the swap (~1e-3).
- End-to-end generation with the swapped metallib + **native NAX** produces clean, prompt-dependent images (apple vs robot have distinct stats; 12/12 clean across prompts × seeds).
- Gate correctly **skips** the swap when the metallib is already good.