### PR TITLE
Fix M5 NAX miscompile detector: probe at model-sized matmul

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -360,11 +360,17 @@ done
 
 # bf16 GPU-vs-CPU matmul check: exit 0 if the GPU kernel is correct (reldiff
 # < 0.1), 1 if it's miscompiled (the M5 NAX bug gives reldiff ~1.1).
+#
+# The probe must be large enough to select the miscompiled M5 NAX GEMM kernel:
+# the bug only manifests at the matmul sizes the model actually uses. A small
+# probe (e.g. 64x512 @ 512x512) reads clean even on a broken build (reldiff
+# ~0), giving a false negative that skips the swap and leaves M5 output gray.
+# 1024x2048 @ 2048x2048 exercises the NAX path (reldiff ~1.1 when miscompiled).
 _mlx_matmul_ok() {
     "$VENV_PY" - <<'PYV'
 import sys, mlx.core as mx
-a = mx.random.normal((64, 512)).astype(mx.bfloat16)
-b = mx.random.normal((512, 512)).astype(mx.bfloat16); mx.eval(a, b)
+a = mx.random.normal((1024, 2048)).astype(mx.bfloat16)
+b = mx.random.normal((2048, 2048)).astype(mx.bfloat16); mx.eval(a, b)
 with mx.stream(mx.gpu): g = (a @ b); mx.eval(g)
 with mx.stream(mx.cpu): c = (a @ b); mx.eval(c)
 g = g.astype(mx.float32); c = c.astype(mx.float32); mx.eval(g, c)


### PR DESCRIPTION
## What
Enlarge the bf16 GPU-vs-CPU matmul probe in `_mlx_matmul_ok` (`setup.sh`) from `64x512 @ 512x512` to `1024x2048 @ 2048x2048`.

## Why
The M5 NAX miscompile detector added in #11 is correct in approach but has a **false negative on M5**: its probe matmul is too small to select the miscompiled NAX GEMM kernel. On a broken source-built metallib the small probe reads clean (reldiff ~0), so `_mlx_matmul_ok` returns OK, the metallib swap is skipped, and a fresh M5 clone still produces gray-brown noise (issue #6).

The miscompile only manifests at the matmul sizes the model actually uses. Measured on M5 Pro (bf16 GPU-vs-CPU reldiff, source-built metallib):

| matmul | reldiff |
|---|---|
| 64x512 @ 512x512 *(old probe)* | 0.0000 ✅ false negative |
| 256x2048 @ 2048 | 0.0021 ✅ |
| 1024x2048 @ 2048 | **1.111** ❌ |
| 4096x4096 @ 4096 | **1.112** ❌ |

(Original diagnosis by @davepeckjr in #6.)

## How / verification
Verified on M5 Pro (Mac17,8), macOS 26.5, Xcode 26.5 (`metalfe-32023.883`):

- Patched probe **passes** (exit 0, no swap) on the prebuilt `mlx-metal` metallib and **trips** (exit 1, triggers swap) on the source-built one — so the swap now fires on fresh M5 clones.
- End-to-end: with the broken metallib, the same prompt+seed produces gray noise (`check_image` std 8.7, FAIL); after the swap fires, real prompt-faithful images (std 61.6, PASS), and two different prompts produce distinct images (reldiff 0.91 vs 0.008 under the bug).

Fixes #6