### PR TITLE
Fix M5 NAX detector false-negative on low-core M5 (Air): probe at model-sized matmul

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -361,16 +361,19 @@ done
 # bf16 GPU-vs-CPU matmul check: exit 0 if the GPU kernel is correct (reldiff
 # < 0.1), 1 if it's miscompiled (the M5 NAX bug gives reldiff ~1.1).
 #
-# The probe must be large enough to select the miscompiled M5 NAX GEMM kernel:
-# the bug only manifests at the matmul sizes the model actually uses. A small
-# probe (e.g. 64x512 @ 512x512) reads clean even on a broken build (reldiff
-# ~0), giving a false negative that skips the swap and leaves M5 output gray.
-# 1024x2048 @ 2048x2048 exercises the NAX path (reldiff ~1.1 when miscompiled).
+# The probe must be large enough to select the miscompiled M5 NAX GEMM kernel
+# on EVERY M5 variant. The NAX dispatch threshold rises as GPU core count drops,
+# so a probe sized for the 20-core M5 Pro (g17s) can stay below the 10-core M5
+# Air's (g17g) threshold and read clean on a broken build — a false negative
+# that skips the swap and leaves output gray (issue #6). History: 64x512 missed
+# the Pro; 1024x2048 @ 2048 still missed the Air. So probe at the model's own
+# matmul size (K=3072, N=12288) — then NAX engages exactly when the model's
+# matmuls do, regardless of core count.
 _mlx_matmul_ok() {
     "$VENV_PY" - <<'PYV'
 import sys, mlx.core as mx
-a = mx.random.normal((1024, 2048)).astype(mx.bfloat16)
-b = mx.random.normal((2048, 2048)).astype(mx.bfloat16); mx.eval(a, b)
+a = mx.random.normal((64, 3072)).astype(mx.bfloat16)
+b = mx.random.normal((3072, 12288)).astype(mx.bfloat16); mx.eval(a, b)
 with mx.stream(mx.gpu): g = (a @ b); mx.eval(g)
 with mx.stream(mx.cpu): c = (a @ b); mx.eval(c)
 g = g.astype(mx.float32); c = c.astype(mx.float32); mx.eval(g, c)


### PR DESCRIPTION
Closes #6 (the M5 Air case reported by @ramiono).

## What
The `setup.sh` NAX-miscompile detector (`_mlx_matmul_ok`) now probes at the model's own matmul size (`64×3072 @ 3072×12288`) instead of `1024×2048 @ 2048×2048`.

## Why
#12 sized the probe for the 20-core M5 **Pro** (`g17s`). But the **NAX dispatch threshold rises as GPU core count drops**, so on the 10-core M5 **Air** (`g17g`) that probe stays *below* the threshold, NAX isn't engaged, the bf16 matmul reads clean on a broken build, and the swap is skipped — leaving output gray. @ramiono and @davepeckjr both pinned this: the miscompile only surfaces at model-sized matmuls on the Air.

Probing at the model's actual matmul dimensions makes the invariant robust regardless of core count: **NAX engages exactly when the model's own matmuls do.** History of the probe size:
- `64×512 @ 512×512` — missed the **Pro** (false negative, #11 → fixed in #12)
- `1024×2048 @ 2048×2048` — trips the Pro but still missed the **Air** (this PR)
- `64×3072 @ 3072×12288` — model-sized; trips on both

## How / verification
On an M5 Pro (`g17s`, macOS 26.5, Xcode 26.5 / `metalfe-32023.883`), same prompt + seed, only the metallib differing:

| metallib | new probe reldiff | exit | action |
|---|---|---|---|
| source-built (broken) | ~1.11 | 1 | swap fires ✅ |
| prebuilt `mlx-metal` | ~0.002 | 0 | no swap ✅ |

`3072×12288` is the exact size @ramiono confirmed trips on the 10-core M5 Air, so this covers Pro + Air. (We can only verify on a Pro locally; the "probe = model matmul" invariant is what guarantees the Air case.) `sh -n setup.sh` clean.