### PR TITLE
Fix macOS: only advertise downloaded Bonsai variants in /backends

### DIFF
--- a/scripts/local_backend_mac.py
+++ b/scripts/local_backend_mac.py
@@ -42,6 +42,12 @@ async def _backends(force_disable: bool = False) -> dict:
     `force_disable` arrives via query string on the upstream route's
     signature; harmless on Mac (no GPU probe to disable) — accepted
     only so the route signature matches the frontend's expectations.
+
+    By default advertises both Bonsai variants (ternary + binary). When
+    serve.sh sets BONSAI_SUPPORTED_FAMILIES, advertise only those
+    downloaded families so the picker can't offer a variant whose
+    weights aren't on disk — selecting an absent arm routes /generate to
+    a non-existent model dir and 500s. Mirrors scripts/local_backend.py.
     """
     arm = os.environ.get("MFLUX_STUDIO_DEFAULT_BACKEND", "bonsai-ternary-mlx")
     if arm.endswith("-mlx"):
@@ -50,9 +56,18 @@ async def _backends(force_disable: bool = False) -> dict:
         default_family = arm[: -len("-gemlite")]
     else:
         default_family = arm
+    allowed_families = {"bonsai-ternary", "bonsai-binary"}
+    configured_families = [
+        family.strip()
+        for family in os.environ.get("BONSAI_SUPPORTED_FAMILIES", "").split(",")
+        if family.strip() in allowed_families
+    ]
+    supported_families = configured_families or ["bonsai-ternary", "bonsai-binary"]
+    if default_family not in supported_families:
+        default_family = supported_families[0]
     return {
         "kind": "mlx",
-        "supported_families": ["bonsai-ternary", "bonsai-binary"],
+        "supported_families": supported_families,
         "default_family": default_family,
         "healthy": True,
         "reason": None,

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -94,6 +94,8 @@ case "$OS" in
         # to a non-existent model dir → 500 ("one missing fails for both").
         _ternary_dir="$DEMO_DIR/models/bonsai-image-4B-ternary-mlx"
         _binary_dir="$DEMO_DIR/models/bonsai-image-4B-binary-mlx"
+        _ternary_present=""
+        _binary_present=""
         [ -d "$_ternary_dir/transformer-packed-mflux" ] && _ternary_present=1
         [ -d "$_binary_dir/transformer-packed-mflux" ] && _binary_present=1
         # The variant being launched must be present; the other is optional.

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -86,6 +86,36 @@ case "$OS" in
         # shim pattern.
         _backend_module="scripts.local_backend_mac:app"
         _model_dir="$DEMO_DIR/models/bonsai-image-4B-${BONSAI_VARIANT}-mlx"
+
+        # Advertise only the variants actually on disk (mirrors the Linux
+        # fix in #16). A variant is "downloaded" when its packed mflux
+        # transformer is present. Without this, /backends offers both arms
+        # even when one is missing; picking the absent one routes /generate
+        # to a non-existent model dir → 500 ("one missing fails for both").
+        _ternary_dir="$DEMO_DIR/models/bonsai-image-4B-ternary-mlx"
+        _binary_dir="$DEMO_DIR/models/bonsai-image-4B-binary-mlx"
+        [ -d "$_ternary_dir/transformer-packed-mflux" ] && _ternary_present=1
+        [ -d "$_binary_dir/transformer-packed-mflux" ] && _binary_present=1
+        # The variant being launched must be present; the other is optional.
+        if [ "$BONSAI_VARIANT" = "binary" ] && [ -z "$_binary_present" ]; then
+            err "no transformer-packed-mflux subdir found under $_binary_dir"
+            err "download the model first: ./scripts/download_model.sh binary"
+            exit 1
+        fi
+        if [ "$BONSAI_VARIANT" = "ternary" ] && [ -z "$_ternary_present" ]; then
+            err "no transformer-packed-mflux subdir found under $_ternary_dir"
+            err "download the model first: ./scripts/download_model.sh ternary"
+            exit 1
+        fi
+        _supported_families=""
+        [ -n "$_ternary_present" ] && _supported_families="bonsai-ternary"
+        if [ -n "$_binary_present" ]; then
+            if [ -n "$_supported_families" ]; then
+                _supported_families="$_supported_families,bonsai-binary"
+            else
+                _supported_families="bonsai-binary"
+            fi
+        fi
         ;;
     Linux)
         # The Linux path swaps to image-studio's GPU backend (gemlite kernels)
@@ -216,6 +246,7 @@ else
     # scripts.local_backend_mac shim (which overrides /backends).
     # No env flag needed for that — see _backend_module above.
     MFLUX_STUDIO_DEFAULT_BACKEND="$_default_backend" \
+    BONSAI_SUPPORTED_FAMILIES="$_supported_families" \
     MFLUX_STUDIO_BAKED_MODEL_PATH="$DEMO_DIR/models/bonsai-image-4B-ternary-mlx" \
     MFLUX_STUDIO_BAKED_BINARY_MODEL_PATH="$DEMO_DIR/models/bonsai-image-4B-binary-mlx" \
     MFLUX_STUDIO_TE_4BIT=true \


### PR DESCRIPTION
Mirrors #16 onto the macOS path. With only one variant downloaded, /backends still advertised both, so picking the missing arm 500'd on /generate. Now serve.sh detects which mlx variants are on disk and local_backend_mac.py honors BONSAI_SUPPORTED_FAMILIES.