### PR TITLE
Add guided top-down terrain workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -37,27 +37,30 @@ jobs:
         if: steps.cache-model.outputs.cache-hit != 'true'
         run: ./scripts/download_model.sh --model ternary-mlx
 
-      - name: Generate a small image (smoke)
+      - name: Generate a top-down heightmap candidate
         run: |
-          ./scripts/generate.sh \
-            -p "a small red square" \
-            --size 256x256 \
-            --steps 4 --seed 42
-          ls -la outputs/ternary-mlx/
-          test "$(ls outputs/ternary-mlx/*.png 2>/dev/null | wc -l)" -ge 1
-          test "$(stat -f%z outputs/ternary-mlx/*.png)" -gt 1024
+          ./scripts/terrain.sh \
+            --prompt "a volcanic island with radial ridges and a central crater" \
+            --mode heightmap \
+            --size 512x512 \
+            --steps 8 \
+            --seed 42 \
+            --skip-check \
+            --output outputs/terrain/heightmap/volcanic-island-seed42.png
+          test "$(stat -f%z outputs/terrain/heightmap/volcanic-island-seed42.png)" -gt 1024
 
-      - name: Check generated image quality (not all-black / not constant noise)
+      - name: Check generated image integrity
         run: |
-          PNG=$(ls outputs/ternary-mlx/*.png | head -1)
+          PNG=outputs/terrain/heightmap/volcanic-island-seed42.png
           .venv/bin/python scripts/check_image.py "$PNG"
+          .venv/bin/python scripts/check_heightmap.py "$PNG"
 
       - name: Upload generated image (always, for visual inspection)
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: macos-generated-image
-          path: outputs/ternary-mlx/*.png
+          path: outputs/terrain/heightmap/*.png
 
       - name: Serve smoke test
         run: |

--- a/README.md
+++ b/README.md
@@ -136,6 +136,24 @@ Default is 512×512 (fast preview). Dimensions have to be multiples of 32. Sugge
 | Tall (1:2)        | 352×704        | 704×1408       |
 
 
+### Top-down terrain and heightmaps
+
+Use the guided terrain workflow instead of trying to force camera geometry through a free-form prompt:
+
+```bash
+./scripts/terrain.sh \
+  --prompt "a volcanic island with radial ridges and a central crater" \
+  --mode heightmap \
+  --size 1024x1024 \
+  --steps 8 \
+  --seed 42 \
+  --open
+```
+
+Choose `--mode texture` for a color terrain reference. A texture is not a heightmap. Heightmap mode expands the description into an orthographic DEM prompt and checks grayscale range after generation. Camera angle and elevation meaning still require visual review.
+
+See [Generate top-down terrain](docs/top-down-terrain.md) for the review checklist and failure policy.
+
 ## Folder structure after setup
 
 ```

--- a/docs/top-down-terrain.md
+++ b/docs/top-down-terrain.md
@@ -42,7 +42,8 @@ The numeric check does not prove camera angle or physical elevation. Before usin
 3. Bright areas consistently mean high ground.
 4. Dark areas consistently mean low ground.
 5. Shading does not create false ridges or valleys.
-6. The terrain reaches the intended map boundary without a perspective frame.
+6. Sea level and the outer map boundary are black, not white or transparent.
+7. The terrain reaches the intended map boundary without a perspective frame.
 
 Reject the image when any point fails. Try another seed before changing the contract. If several seeds fail in the same way, record the outputs and treat the behavior as a model limitation rather than a prompt-writing failure.
 

--- a/docs/top-down-terrain.md
+++ b/docs/top-down-terrain.md
@@ -1,0 +1,59 @@
+# Generate top-down terrain
+
+Use the terrain workflow when the camera must look straight down. Do not start by adding more camera words to a free-form prompt. Choose the output you need first.
+
+## Choose the output
+
+`heightmap` creates a grayscale elevation candidate. Brightness means height. Use this for terrain displacement after review.
+
+`texture` creates a color terrain reference. Color describes the surface. It is not elevation data.
+
+## First run
+
+Preview the full prompt without loading the model:
+
+```bash
+python3 scripts/generate_terrain.py \
+  --prompt "a volcanic island with radial ridges and a central crater" \
+  --mode heightmap \
+  --dry-run
+```
+
+After `./setup.sh` succeeds, generate a fixed result:
+
+```bash
+./scripts/terrain.sh \
+  --prompt "a volcanic island with radial ridges and a central crater" \
+  --mode heightmap \
+  --size 1024x1024 \
+  --steps 8 \
+  --seed 42 \
+  --open
+```
+
+The command expands the short description into an orthographic GIS elevation contract. It then checks grayscale saturation, usable tonal range, and clipping.
+
+## Review the result
+
+The numeric check does not prove camera angle or physical elevation. Before using the image as a heightmap, confirm all of these points:
+
+1. There is no visible horizon, sky, or side face.
+2. The view is vertical rather than oblique or isometric.
+3. Bright areas consistently mean high ground.
+4. Dark areas consistently mean low ground.
+5. Shading does not create false ridges or valleys.
+6. The terrain reaches the intended map boundary without a perspective frame.
+
+Reject the image when any point fails. Try another seed before changing the contract. If several seeds fail in the same way, record the outputs and treat the behavior as a model limitation rather than a prompt-writing failure.
+
+## Check an existing image
+
+```bash
+.venv/bin/python scripts/check_heightmap.py outputs/terrain/heightmap/example.png
+```
+
+Use `--json` for automation. A pass means only that the pixels have a usable grayscale range. It does not certify geometry.
+
+## Current setup requirement
+
+On Apple Silicon, local generation requires full Xcode and its Metal Toolchain. Command Line Tools alone are not enough for the pinned MLX build. Run `./setup.sh`; it reports the exact missing prerequisite before downloading the model.

--- a/docs/top-down-terrain.md
+++ b/docs/top-down-terrain.md
@@ -47,13 +47,21 @@ The numeric check does not prove camera angle or physical elevation. Before usin
 
 Reject the image when any point fails. Try another seed before changing the contract. If several seeds fail in the same way, record the outputs and treat the behavior as a model limitation rather than a prompt-writing failure.
 
+## What we verified
+
+The ternary MLX model can follow the absolute top-down composition. In a fixed-seed volcanic-island test, it produced a centered nadir view with no horizon. Adding a black sea-level boundary also changed the frame from white to black.
+
+It did not produce dependable raw elevation data. The same test retained strong highlights and shadows after the prompt asked for raw raster values and no shaded relief. Those pixels describe lighting, not height. The current FLUX.2 Klein pipeline does not support a negative-prompt channel, so adding more exclusion words is not a reliable fix.
+
+Use the output as a top-down terrain reference unless it passes the visual checklist. For production heightmaps, use a terrain or elevation tool that computes height values instead of inferring them from an image model.
+
 ## Check an existing image
 
 ```bash
 .venv/bin/python scripts/check_heightmap.py outputs/terrain/heightmap/example.png
 ```
 
-Use `--json` for automation. A pass means only that the pixels have a usable grayscale range. It does not certify geometry.
+Use `--json` for automation. `numeric_pass` means only that the pixels have a usable grayscale range and boundary. `visual_review_required` is always true because the checker cannot prove projection or distinguish elevation from relief lighting.
 
 ## Current setup requirement
 

--- a/scripts/check_heightmap.py
+++ b/scripts/check_heightmap.py
@@ -19,6 +19,7 @@ class HeightmapReport:
     tonal_span: int
     clipped_low_percent: float
     clipped_high_percent: float
+    bright_border_percent: float
     numeric_pass: bool
     failures: tuple[str, ...]
 
@@ -51,6 +52,16 @@ def inspect_heightmap(path: Path) -> HeightmapReport:
         saturation_percent = ImageStat.Stat(hsv).mean[1] / 255 * 100
         clipped_low_percent = sum(histogram[:6]) / pixels * 100
         clipped_high_percent = sum(histogram[250:]) / pixels * 100
+        border_width = max(1, min(width, height) // 64)
+        border_regions = (
+            gray.crop((0, 0, width, border_width)),
+            gray.crop((0, height - border_width, width, height)),
+            gray.crop((0, border_width, border_width, height - border_width)),
+            gray.crop((width - border_width, border_width, width, height - border_width)),
+        )
+        border_pixels = sum(region.width * region.height for region in border_regions)
+        bright_border_pixels = sum(sum(region.histogram()[250:]) for region in border_regions)
+        bright_border_percent = bright_border_pixels / border_pixels * 100
 
     failures: list[str] = []
     if saturation_percent > 8:
@@ -63,6 +74,11 @@ def inspect_heightmap(path: Path) -> HeightmapReport:
         failures.append(f"{clipped_low_percent:.1f}% of pixels are crushed near black")
     if clipped_high_percent > 35:
         failures.append(f"{clipped_high_percent:.1f}% of pixels are clipped near white")
+    if bright_border_percent > 35:
+        failures.append(
+            f"{bright_border_percent:.1f}% of the map border is near white; "
+            "the lowest elevation should frame the terrain"
+        )
 
     return HeightmapReport(
         width=width,
@@ -73,6 +89,7 @@ def inspect_heightmap(path: Path) -> HeightmapReport:
         tonal_span=p95 - p05,
         clipped_low_percent=round(clipped_low_percent, 2),
         clipped_high_percent=round(clipped_high_percent, 2),
+        bright_border_percent=round(bright_border_percent, 2),
         numeric_pass=not failures,
         failures=tuple(failures),
     )
@@ -100,7 +117,8 @@ def main() -> None:
             f"heightmap: {report.width}x{report.height}  "
             f"saturation={report.saturation_percent:.1f}%  "
             f"range=p05:{report.p05}-p95:{report.p95}  "
-            f"clipping={report.clipped_low_percent:.1f}%/{report.clipped_high_percent:.1f}%"
+            f"clipping={report.clipped_low_percent:.1f}%/{report.clipped_high_percent:.1f}%  "
+            f"bright-border={report.bright_border_percent:.1f}%"
         )
         for failure in report.failures:
             print(f"FAIL: {failure}", file=sys.stderr)

--- a/scripts/check_heightmap.py
+++ b/scripts/check_heightmap.py
@@ -21,6 +21,7 @@ class HeightmapReport:
     clipped_high_percent: float
     bright_border_percent: float
     numeric_pass: bool
+    visual_review_required: bool
     failures: tuple[str, ...]
 
 
@@ -70,8 +71,6 @@ def inspect_heightmap(path: Path) -> HeightmapReport:
         )
     if p95 - p05 < 80:
         failures.append(f"tonal span is {p95 - p05}; elevation separation is too narrow")
-    if clipped_low_percent > 35:
-        failures.append(f"{clipped_low_percent:.1f}% of pixels are crushed near black")
     if clipped_high_percent > 35:
         failures.append(f"{clipped_high_percent:.1f}% of pixels are clipped near white")
     if bright_border_percent > 35:
@@ -91,6 +90,7 @@ def inspect_heightmap(path: Path) -> HeightmapReport:
         clipped_high_percent=round(clipped_high_percent, 2),
         bright_border_percent=round(bright_border_percent, 2),
         numeric_pass=not failures,
+        visual_review_required=True,
         failures=tuple(failures),
     )
 

--- a/scripts/check_heightmap.py
+++ b/scripts/check_heightmap.py
@@ -1,0 +1,116 @@
+"""Check whether an image is numerically usable as a heightmap candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class HeightmapReport:
+    width: int
+    height: int
+    saturation_percent: float
+    p05: int
+    p95: int
+    tonal_span: int
+    clipped_low_percent: float
+    clipped_high_percent: float
+    numeric_pass: bool
+    failures: tuple[str, ...]
+
+
+def _percentile(histogram: list[int], fraction: float, total: int) -> int:
+    target = total * fraction
+    seen = 0
+    for value, count in enumerate(histogram):
+        seen += count
+        if seen >= target:
+            return value
+    return 255
+
+
+def inspect_heightmap(path: Path) -> HeightmapReport:
+    try:
+        from PIL import Image, ImageStat
+    except ImportError as exc:
+        raise RuntimeError("Pillow is required; run ./setup.sh first") from exc
+
+    with Image.open(path) as source:
+        rgb = source.convert("RGB")
+        gray = rgb.convert("L")
+        hsv = rgb.convert("HSV")
+        width, height = rgb.size
+        histogram = gray.histogram()
+        pixels = width * height
+        p05 = _percentile(histogram, 0.05, pixels)
+        p95 = _percentile(histogram, 0.95, pixels)
+        saturation_percent = ImageStat.Stat(hsv).mean[1] / 255 * 100
+        clipped_low_percent = sum(histogram[:6]) / pixels * 100
+        clipped_high_percent = sum(histogram[250:]) / pixels * 100
+
+    failures: list[str] = []
+    if saturation_percent > 8:
+        failures.append(
+            f"color saturation is {saturation_percent:.1f}%; a heightmap should be grayscale"
+        )
+    if p95 - p05 < 80:
+        failures.append(f"tonal span is {p95 - p05}; elevation separation is too narrow")
+    if clipped_low_percent > 35:
+        failures.append(f"{clipped_low_percent:.1f}% of pixels are crushed near black")
+    if clipped_high_percent > 35:
+        failures.append(f"{clipped_high_percent:.1f}% of pixels are clipped near white")
+
+    return HeightmapReport(
+        width=width,
+        height=height,
+        saturation_percent=round(saturation_percent, 2),
+        p05=p05,
+        p95=p95,
+        tonal_span=p95 - p05,
+        clipped_low_percent=round(clipped_low_percent, 2),
+        clipped_high_percent=round(clipped_high_percent, 2),
+        numeric_pass=not failures,
+        failures=tuple(failures),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check grayscale and elevation range in a heightmap candidate."
+    )
+    parser.add_argument("image", type=Path)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    args = parser.parse_args()
+
+    if not args.image.is_file():
+        parser.error(f"image not found: {args.image}")
+    try:
+        report = inspect_heightmap(args.image)
+    except RuntimeError as exc:
+        sys.exit(str(exc))
+
+    if args.json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        print(
+            f"heightmap: {report.width}x{report.height}  "
+            f"saturation={report.saturation_percent:.1f}%  "
+            f"range=p05:{report.p05}-p95:{report.p95}  "
+            f"clipping={report.clipped_low_percent:.1f}%/{report.clipped_high_percent:.1f}%"
+        )
+        for failure in report.failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        if report.numeric_pass:
+            print("PASS: grayscale and elevation range are usable.")
+        print("REVIEW: confirm a true top-down projection before using this as elevation data.")
+
+    if not report.numeric_pass:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_terrain.py
+++ b/scripts/generate_terrain.py
@@ -1,0 +1,115 @@
+"""Generate a guided top-down terrain image with the existing Bonsai CLI."""
+
+from __future__ import annotations
+
+import argparse
+import secrets
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from terrain_prompt import build_terrain_prompt
+
+DEMO_DIR = Path(__file__).resolve().parent.parent
+
+
+def parse_size(value: str) -> str:
+    normalized = value.lower().replace("×", "x")
+    try:
+        width_text, height_text = normalized.split("x", 1)
+        width, height = int(width_text), int(height_text)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("size must be WIDTHxHEIGHT") from exc
+    if width != height:
+        raise argparse.ArgumentTypeError("terrain outputs must be square")
+    if not 256 <= width <= 2048 or width % 32:
+        raise argparse.ArgumentTypeError("terrain size must be 256-2048 and a multiple of 32")
+    return f"{width}x{height}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an orthographic terrain heightmap or texture with Bonsai."
+    )
+    parser.add_argument("-p", "--prompt", required=True, help="Describe the landform only.")
+    parser.add_argument("--mode", choices=("heightmap", "texture"), default="heightmap")
+    parser.add_argument("--size", type=parse_size, default="1024x1024")
+    parser.add_argument("--steps", type=int, default=8)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--model")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--open", action="store_true")
+    parser.add_argument(
+        "--force-gpu-run",
+        action="store_true",
+        help="Linux only: allow the existing generator to run in-process.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print the expanded prompt only.")
+    parser.add_argument(
+        "--skip-check", action="store_true", help="Skip numeric checks for heightmap mode."
+    )
+    return parser.parse_args()
+
+
+def build_command(
+    args: argparse.Namespace, expanded_prompt: str, seed: int, output: Path
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(DEMO_DIR / "scripts" / "generate.py"),
+        "--prompt",
+        expanded_prompt,
+        "--size",
+        args.size,
+        "--steps",
+        str(args.steps),
+        "--seed",
+        str(seed),
+        "--output",
+        str(output),
+    ]
+    if args.model:
+        command.extend(("--model", args.model))
+    if args.open:
+        command.append("--open")
+    if args.force_gpu_run:
+        command.append("--force-gpu-run")
+    return command
+
+
+def main() -> None:
+    args = parse_args()
+    expanded_prompt = build_terrain_prompt(args.prompt, args.mode)
+    if args.dry_run:
+        print(expanded_prompt)
+        return
+
+    seed = args.seed if args.seed is not None else secrets.randbits(31)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output = (
+        args.output.expanduser().resolve()
+        if args.output
+        else DEMO_DIR
+        / "outputs"
+        / "terrain"
+        / args.mode
+        / f"terrain_{timestamp}_seed{seed}.png"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    command = build_command(args, expanded_prompt, seed, output)
+
+    print(f"Terrain mode: {args.mode}")
+    print(f"Expanded prompt: {expanded_prompt}")
+    subprocess.run(command, check=True)
+
+    if args.mode == "heightmap" and not args.skip_check:
+        subprocess.run(
+            [sys.executable, str(DEMO_DIR / "scripts" / "check_heightmap.py"), str(output)],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/terrain.sh
+++ b/scripts/terrain.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Guided wrapper for orthographic terrain and heightmap candidates.
+set -e
+
+DEMO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+. "$DEMO_DIR/scripts/common.sh"
+ensure_venv "$DEMO_DIR"
+
+exec "$DEMO_DIR/.venv/bin/python" "$DEMO_DIR/scripts/generate_terrain.py" "$@"

--- a/scripts/terrain_prompt.py
+++ b/scripts/terrain_prompt.py
@@ -9,11 +9,12 @@ TerrainMode = Literal["heightmap", "texture"]
 HEIGHTMAP_CONTRACT = (
     "A single-channel grayscale digital elevation model (DEM) of {description}. "
     "Absolute orthographic nadir projection, viewed vertically from exactly 90 degrees above. "
-    "The image is a flat square GIS elevation raster with the full terrain footprint visible. "
+    "Raw 2D raster data, not a 3D render, with the full terrain footprint visible. "
     "Pixel brightness encodes elevation only: pure black is the lowest ground and pure white is "
     "the highest ground, with smooth continuous gray elevation gradients between them. "
-    "Uniform shadowless illumination, neutral grayscale surface, clean map edges, high relief "
-    "separation, scientific terrain height field."
+    "Sea level and the outer map boundary are black. No lighting, shadows, highlights, ambient "
+    "occlusion, texture, bevel, embossing, or shaded relief. Clean square map edges, strong "
+    "elevation separation, scientific terrain height field."
 )
 
 TEXTURE_CONTRACT = (

--- a/scripts/terrain_prompt.py
+++ b/scripts/terrain_prompt.py
@@ -1,0 +1,36 @@
+"""Prompt contracts for orthographic terrain generation."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+TerrainMode = Literal["heightmap", "texture"]
+
+HEIGHTMAP_CONTRACT = (
+    "A single-channel grayscale digital elevation model (DEM) of {description}. "
+    "Absolute orthographic nadir projection, viewed vertically from exactly 90 degrees above. "
+    "The image is a flat square GIS elevation raster with the full terrain footprint visible. "
+    "Pixel brightness encodes elevation only: pure black is the lowest ground and pure white is "
+    "the highest ground, with smooth continuous gray elevation gradients between them. "
+    "Uniform shadowless illumination, neutral grayscale surface, clean map edges, high relief "
+    "separation, scientific terrain height field."
+)
+
+TEXTURE_CONTRACT = (
+    "An orthographic terrain texture map of {description}. Absolute nadir projection, viewed "
+    "vertically from exactly 90 degrees above. The full terrain footprint is visible as a flat "
+    "square game-development map tile. Even diffuse lighting, readable land cover, consistent "
+    "scale, clean map edges, detailed natural terrain surface."
+)
+
+
+def build_terrain_prompt(description: str, mode: TerrainMode = "heightmap") -> str:
+    """Expand a landform description into one explicit terrain contract."""
+    clean = " ".join(description.split()).strip(" .")
+    if not clean:
+        raise ValueError("terrain description cannot be empty")
+    if mode == "heightmap":
+        return HEIGHTMAP_CONTRACT.format(description=clean)
+    if mode == "texture":
+        return TEXTURE_CONTRACT.format(description=clean)
+    raise ValueError(f"unsupported terrain mode: {mode}")

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from generate_terrain import build_command, parse_size  # noqa: E402
+from check_heightmap import inspect_heightmap  # noqa: E402
+from terrain_prompt import build_terrain_prompt  # noqa: E402
+
+
+class TerrainPromptTests(unittest.TestCase):
+    def test_heightmap_contract_states_projection_and_elevation_encoding(self) -> None:
+        prompt = build_terrain_prompt("a volcanic island with radial ridges")
+        self.assertIn("orthographic nadir", prompt)
+        self.assertIn("exactly 90 degrees above", prompt)
+        self.assertIn("brightness encodes elevation only", prompt)
+        self.assertIn("black is the lowest", prompt)
+        self.assertIn("white is the highest", prompt)
+        self.assertIn("volcanic island", prompt)
+
+    def test_texture_mode_does_not_claim_to_be_a_heightmap(self) -> None:
+        prompt = build_terrain_prompt("an alpine valley", "texture")
+        self.assertIn("terrain texture map", prompt)
+        self.assertNotIn("brightness encodes elevation", prompt)
+
+    def test_empty_description_fails(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot be empty"):
+            build_terrain_prompt("   ")
+
+    def test_size_requires_square_multiple_of_32(self) -> None:
+        self.assertEqual(parse_size("1024x1024"), "1024x1024")
+        self.assertEqual(parse_size("512×512"), "512x512")
+        with self.assertRaisesRegex(Exception, "square"):
+            parse_size("1024x768")
+        with self.assertRaisesRegex(Exception, "multiple of 32"):
+            parse_size("1000x1000")
+
+    def test_guided_request_is_forwarded_to_existing_generator(self) -> None:
+        args = Namespace(
+            size="1024x1024",
+            steps=8,
+            model="ternary-gemlite",
+            open=True,
+            force_gpu_run=True,
+        )
+        output = ROOT / "outputs" / "terrain" / "heightmap" / "candidate.png"
+        prompt = build_terrain_prompt("a glacial valley")
+
+        command = build_command(args, prompt, 42, output)
+
+        self.assertEqual(command[1], str(ROOT / "scripts" / "generate.py"))
+        self.assertEqual(command[command.index("--prompt") + 1], prompt)
+        self.assertEqual(command[command.index("--size") + 1], "1024x1024")
+        self.assertEqual(command[command.index("--steps") + 1], "8")
+        self.assertEqual(command[command.index("--seed") + 1], "42")
+        self.assertEqual(command[command.index("--output") + 1], str(output))
+        self.assertEqual(command[command.index("--model") + 1], "ternary-gemlite")
+        self.assertIn("--open", command)
+        self.assertIn("--force-gpu-run", command)
+
+
+class HeightmapCheckTests(unittest.TestCase):
+    def save_image(self, image: Image.Image) -> Path:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "candidate.png"
+        image.save(path)
+        return path
+
+    def test_grayscale_gradient_passes(self) -> None:
+        image = Image.new("L", (256, 256))
+        image.putdata([x for _y in range(256) for x in range(256)])
+        report = inspect_heightmap(self.save_image(image))
+        self.assertTrue(report.numeric_pass)
+        self.assertGreaterEqual(report.tonal_span, 200)
+        self.assertEqual(report.saturation_percent, 0)
+
+    def test_narrow_tonal_range_fails(self) -> None:
+        report = inspect_heightmap(self.save_image(Image.new("L", (256, 256), 120)))
+        self.assertFalse(report.numeric_pass)
+        self.assertTrue(any("tonal span" in failure for failure in report.failures))
+
+    def test_color_image_fails(self) -> None:
+        report = inspect_heightmap(self.save_image(Image.new("RGB", (256, 256), (180, 40, 20))))
+        self.assertFalse(report.numeric_pass)
+        self.assertTrue(any("color saturation" in failure for failure in report.failures))
+
+    def test_crushed_extremes_fail(self) -> None:
+        image = Image.new("L", (256, 256))
+        image.putdata([0 if index % 2 else 255 for index in range(256 * 256)])
+        report = inspect_heightmap(self.save_image(image))
+        self.assertFalse(report.numeric_pass)
+        self.assertTrue(any("crushed" in failure for failure in report.failures))
+        self.assertTrue(any("clipped" in failure for failure in report.failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -96,13 +96,24 @@ class HeightmapCheckTests(unittest.TestCase):
         self.assertFalse(report.numeric_pass)
         self.assertTrue(any("color saturation" in failure for failure in report.failures))
 
-    def test_crushed_extremes_fail(self) -> None:
+    def test_clipped_highlights_fail(self) -> None:
         image = Image.new("L", (256, 256))
         image.putdata([0 if index % 2 else 255 for index in range(256 * 256)])
         report = inspect_heightmap(self.save_image(image))
         self.assertFalse(report.numeric_pass)
-        self.assertTrue(any("crushed" in failure for failure in report.failures))
         self.assertTrue(any("clipped" in failure for failure in report.failures))
+
+    def test_black_sea_level_area_is_allowed(self) -> None:
+        image = Image.new("L", (256, 256), 0)
+        land = Image.new("L", (176, 176))
+        land.putdata([20 + x * 220 // 175 for _y in range(176) for x in range(176)])
+        image.paste(land, (40, 40))
+
+        report = inspect_heightmap(self.save_image(image))
+
+        self.assertTrue(report.numeric_pass)
+        self.assertGreater(report.clipped_low_percent, 35)
+        self.assertTrue(report.visual_review_required)
 
     def test_white_frame_fails_even_when_interior_has_range(self) -> None:
         image = Image.new("L", (256, 256), 255)

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -24,6 +24,9 @@ class TerrainPromptTests(unittest.TestCase):
         self.assertIn("brightness encodes elevation only", prompt)
         self.assertIn("black is the lowest", prompt)
         self.assertIn("white is the highest", prompt)
+        self.assertIn("not a 3D render", prompt)
+        self.assertIn("outer map boundary are black", prompt)
+        self.assertIn("No lighting, shadows, highlights", prompt)
         self.assertIn("volcanic island", prompt)
 
     def test_texture_mode_does_not_claim_to_be_a_heightmap(self) -> None:
@@ -100,6 +103,18 @@ class HeightmapCheckTests(unittest.TestCase):
         self.assertFalse(report.numeric_pass)
         self.assertTrue(any("crushed" in failure for failure in report.failures))
         self.assertTrue(any("clipped" in failure for failure in report.failures))
+
+    def test_white_frame_fails_even_when_interior_has_range(self) -> None:
+        image = Image.new("L", (256, 256), 255)
+        interior = Image.new("L", (224, 224))
+        interior.putdata([x * 255 // 223 for _y in range(224) for x in range(224)])
+        image.paste(interior, (16, 16))
+
+        report = inspect_heightmap(self.save_image(image))
+
+        self.assertFalse(report.numeric_pass)
+        self.assertGreater(report.bright_border_percent, 90)
+        self.assertTrue(any("map border" in failure for failure in report.failures))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a guided `terrain.sh` workflow for absolute top-down terrain references and heightmap candidates
- separate color terrain textures from grayscale elevation candidates
- validate grayscale range, clipping, and map boundaries without claiming to prove geometry
- document the required visual review and the verified FLUX.2 Klein limitation
- exercise the terrain path in the macOS E2E workflow and retain its generated artifact

## Verified behavior

Fixed inputs: ternary MLX, 512x512, 8 steps, seed 42, volcanic island with radial ridges and a central crater.

- Baseline contract produced an absolute top-down image but used a white frame. Numeric result: saturation 1.4%, p05-p95 81-255, 74.7% bright border.
- Revised contract produced an absolute top-down image with a black sea-level frame. Numeric result: saturation 4.6%, p05-p95 0-190, 0% bright border.
- Both images retained relief lighting. They are useful top-down references but are not verified raw heightmaps.
- FLUX.2 Klein does not expose negative prompting, so the guide treats repeated relief shading as a model limit rather than a user prompt failure.

E2E runs:

- https://github.com/ChaiWithJai/Bonsai-Image-Demo/actions/runs/33789106285
- https://github.com/ChaiWithJai/Bonsai-Image-Demo/actions/runs/33790052980

## Tests

- `python -m unittest discover -s tests -v` (11 passing)
- Python compile checks
- shell syntax check
- workflow YAML parse
- `git diff --check`
- macOS Apple Silicon model generation
- Windows setup and model verification
